### PR TITLE
Make home page responsive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,12 @@ align-items: center;
 
   position: relative;
   z-index: 1;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
 `
 const NavLink = styled.a`
 text-align: center;

--- a/src/composants/MidProject.jsx
+++ b/src/composants/MidProject.jsx
@@ -32,10 +32,14 @@ const SemiPhoto = styled.div`
 
 const SemiBigProj = styled.a`
 display: flex;
-width : 49%;
+width: 49%;
 flex-direction: column;
 align-items: flex-start;
 gap: 6px;
+
+@media (max-width: 768px) {
+  width: 100%;
+}
 `
 
 // Le composant MyBlock reçoit des props (title, description, imageUrl)

--- a/src/composants/SmallProject.jsx
+++ b/src/composants/SmallProject.jsx
@@ -32,10 +32,14 @@ const SemiPhoto = styled.div`
 
 const SemiBigProj = styled.div`
 display: flex;
-width :32%;
+width: 32%;
 flex-direction: column;
 align-items: flex-start;
 gap: 6px;
+
+@media (max-width: 768px) {
+  width: 100%;
+}
 `
 
 export default function SmallProject({ Branding, Project, imageUrl, TL, DescriptionText }) {

--- a/src/index.css
+++ b/src/index.css
@@ -198,3 +198,55 @@ align-self: stretch;
 video::-webkit-media-controls-panel {
 display: none !important;
 opacity: 1 !important;}
+
+/* Responsive rules for smaller screens */
+@media (max-width: 768px) {
+  body {
+    padding: 20px;
+  }
+
+  .Title {
+    font-size: 48px;
+  }
+
+  .H2 {
+    font-size: 24px;
+  }
+
+  .Text,
+  .Caps-text,
+  .Small-text,
+  .CAPS-Small-text {
+    font-size: 16px;
+  }
+
+  .overview {
+    width: 100%;
+  }
+
+  .fond-couleur {
+    width: 100%;
+    height: 300px;
+  }
+
+  .pres {
+    margin-top: 300px;
+  }
+
+  .socials {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .arrow-link {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .NavLinks {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}
+

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,7 +10,12 @@ export default function Home() {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  align-self: stretch;;
+  align-self: stretch;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 24px;
+  }
   `
 
   const ThreeProj = styled.div`
@@ -18,6 +23,11 @@ export default function Home() {
   justify-content: space-between;
   align-items: flex-start;
   align-self: stretch;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 24px;
+  }
   `
 
     return (

--- a/src/pages/Work.jsx
+++ b/src/pages/Work.jsx
@@ -12,7 +12,12 @@ const TwoProj = styled.div`
 display: flex;
 justify-content: space-between;
 align-items: flex-start;
-align-self: stretch;;
+align-self: stretch;
+
+@media (max-width: 768px) {
+  flex-direction: column;
+  gap: 24px;
+}
 `
 
 const ThreeProj = styled.div`
@@ -20,6 +25,11 @@ display: flex;
 justify-content: space-between;
 align-items: flex-start;
 align-self: stretch;;
+
+@media (max-width: 768px) {
+  flex-direction: column;
+  gap: 24px;
+}
 `
 
 


### PR DESCRIPTION
## Summary
- add responsive CSS rules for small screens
- make nav bar responsive
- update home and work layouts to stack on small screens
- allow project tiles to fill width on small screens

## Testing
- `npm run lint` *(fails: no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa305b688325aa8e78c8cae8cc2a